### PR TITLE
Update compileSdk/targetSdk to 36 for 2026 Android requirements

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -11,14 +11,14 @@ plugins {
 
 android {
     namespace "co.japl.android.torressansebastian"
-    compileSdk 35
+    compileSdk 36
 
     defaultConfig {
         applicationId "co.japl.android.torressansebastian"
         minSdk 26
-        targetSdk 35
-        versionCode 1_02_8_43
-        versionName "V1.02.8 build 43 Actualización a SDK 35 y despliegue desde github actions automaticamente"
+        targetSdk 36
+        versionCode 1_02_8_44
+        versionName "V1.02.8 build 44 Actualización a SDK 36 y despliegue desde github actions automaticamente"
 
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
         vectorDrawables{

--- a/urtss-android-core/build.gradle.kts
+++ b/urtss-android-core/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
 
 android {
     namespace = "co.urtss.core"
-    compileSdk = 34
+    compileSdk = 36
 
     defaultConfig {
         minSdk = 26


### PR DESCRIPTION
This PR updates the Android compile and target SDK versions to 36 to comply with Google Play's 2026 requirement to target Android 16 (API Level 36). It also increments the application's versionCode and versionName accordingly, while keeping the minor version (02) unchanged.

---
*PR created automatically by Jules for task [1889580857922454087](https://jules.google.com/task/1889580857922454087) started by @nano871022*